### PR TITLE
feat: add is_part_of field in brief and full document views

### DIFF
--- a/reroils_data/documents_items/static/templates/reroils_data/brief_view_documents_items.html
+++ b/reroils_data/documents_items/static/templates/reroils_data/brief_view_documents_items.html
@@ -6,6 +6,7 @@
       </div>
       <div class="col-xs-11">
         <h3><a target="_self" ng-href="/documents/{{ record.id }}">{{ record.metadata.title }}</a></h3>
+
         <!-- author -->
         <ul class="list-inline" ng-show='record.metadata.authors.length > 0'>
             <li ng-repeat='author in record.metadata.authors.slice(0,3)'>
@@ -16,6 +17,9 @@
             </li>
             <li ng-show='record.metadata.authors.length > 3'>; …</li>
         </ul>
+
+        <!-- is_part_of -->
+        <span ng-if="record.metadata.is_part_of">{{ record.metadata.is_part_of }}</span>
 
         <!-- publishers -->
         <ul class="list-inline" ng-show='record.metadata.publishers.length > 0'>

--- a/reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html
+++ b/reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html
@@ -35,7 +35,6 @@
     </div>
     {% endif %}
 
-
     {% if record.publishers|length > 0 %}
     <div class="row">
         <div class="col-xs-2">
@@ -129,6 +128,17 @@
         </div>
         <div class="col-xs-9">
             {{ record.titlesProper|join('; ') }}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if record.is_part_of %}
+    <div class="row">
+        <div class="col-xs-2">
+            {{_('Is part of')}}:
+        </div>
+        <div class="col-xs-9">
+            {{ record.is_part_of }}
         </div>
     </div>
     {% endif %}

--- a/reroils_data/translations/de/LC_MESSAGES/messages.po
+++ b/reroils_data/translations/de/LC_MESSAGES/messages.po
@@ -1,9 +1,9 @@
-# Translations template for reroils-data.
+# German translations for reroils-data.
 # Copyright (C) 2018 RERO
 # This file is distributed under the same license as the reroils-data
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 # Translators:
 # Peter Weber <peter.weber@rero.ch>, 2018
 # iGor milhit <igor.milhit@rero.ch>, 2018
@@ -14,16 +14,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: reroils-data 0.1.0a13\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2018-06-26 10:22+0200\n"
+"POT-Creation-Date: 2018-08-10 07:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Nicolas Labat <n-labat@hotmail.com>, 2018\n"
+"Language: de\n"
 "Language-Team: German (https://www.transifex.com/rero/teams/77935/de/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
-"Language: de\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. NOTE: This is a note to a translator.
 #: reroils_data/ext.py:43
@@ -35,20 +35,20 @@ msgid "available"
 msgstr "verfügbar"
 
 #: reroils_data/filter.py:68
+msgid "on_site consultation"
+msgstr "Vor Ort lesbar"
+
+#: reroils_data/filter.py:70
 msgid "not available"
 msgstr "nicht verfügbar"
 
-#: reroils_data/filter.py:75
+#: reroils_data/filter.py:77
 msgid "due until"
 msgstr "Fällig am"
 
-#: reroils_data/filter.py:77
+#: reroils_data/filter.py:79
 msgid "requested"
 msgstr "Bestellt"
-
-#: reroils_data/filter.py:81
-msgid "on_site consultation"
-msgstr "Vor Ort lesbar"
 
 #: reroils_data/documents/views.py:63
 msgid "The record has been imported."
@@ -106,12 +106,12 @@ msgid "Submit"
 msgstr "Speichern"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:26
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:248
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:271
 msgid "Identifiers"
 msgstr "Identifikatoren"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:38
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:20
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:21
 msgid "Document ID"
 msgstr "Dokument ID"
 
@@ -120,8 +120,8 @@ msgid "Persistent identifier, automatically generated."
 msgstr "Permanente Identifikatoren, automatisch generiert"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:50
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:267
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:159
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:290
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:177
 msgid "ISBN"
 msgstr "ISBN"
 
@@ -130,8 +130,8 @@ msgid "Import"
 msgstr "importieren"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:77
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:25
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:215
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:42
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:238
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:52
 msgid "Title"
 msgstr "Titel"
@@ -220,15 +220,15 @@ msgid "Spanish"
 msgstr "Spanisch"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:215
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:161
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:184
 msgid "Date of publication"
 msgstr "Erscheinungsdatum"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:3
-msgid "Schema for book"
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:3
+msgid "Schema for document"
 msgstr "Schema für ein Buch"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:14
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:15
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:17
 #: reroils_data/locations/jsonschemas/locations/location-v0.0.1.json:15
 #: reroils_data/members/jsonschemas/members/member-v0.0.1.json:14
@@ -237,73 +237,97 @@ msgstr "Schema für ein Buch"
 msgid "Schema"
 msgstr "Schema"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:15
-msgid "Schema to validate book document against."
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:16
+msgid "Schema to validate document against."
 msgstr "Schema zur Validierung von Datensätzen von Monographien."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:26
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:27
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:26
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:129
+#: reroils_data/items/form_options/items/item-v0.0.1.json:84
+#: reroils_data/items/templates/reroils_data/_item_head.html:17
+#: reroils_data/patrons/templates/reroils_data/detailed_view_patrons.html:24
+msgid "Type"
+msgstr "Typ"
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:27
+msgid "Document type."
+msgstr "Dokument an der Ausleihe"
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:29
+msgid "Required. Type of the document. Should be selected in the list below."
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:43
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:44
 msgid "Required. Entire title without statement of responsibility."
 msgstr "Erforderlich. Vollständiger Titel ohne Verantwortlichkeitsangabe."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:32
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:49
 msgid "Proper or uniformed title"
 msgstr "Einheitstitel"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:33
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:50
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
 msgstr ""
 "Einheitstitel, ein verwandter oder analytischer Titel, der von einer "
-"Autoritätsdatei oder -liste kontrolliert und als zusätzlicher Sucheinstieg "
-"verwendet wird."
+"Autoritätsdatei oder -liste kontrolliert und als zusätzlicher "
+"Sucheinstieg verwendet wird."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:42
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:59
+msgid "Is part of"
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:60
+msgid "Title of the host document."
+msgstr "Titel der Reihe."
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:65
 msgid "Languages"
 msgstr "Sprachen"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:43
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:66
 msgid "List of languages for the resource."
 msgstr "Liste der Sprachen der Ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:54
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:77
 msgid "Language"
 msgstr "Sprache"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:55
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:57
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:78
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:80
 msgid "Required. Language of the resource, primary or not."
 msgstr "Erforderlich. Haupt- oder Nebensprache der Ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:77
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:100
 msgid "Translated from"
 msgstr "Übersetzt aus"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:78
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:101
 msgid "Language from which a resource is translated."
 msgstr "Sprache, aus deren die Ressource übersetzt wurde."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:84
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:107
 msgid ""
-"Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> for "
-"English."
+"Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> "
+"for English."
 msgstr ""
-"Soll im ISO-639-Format mit 3 Zeichen vorliegen (z.B. <code>eng</code> für "
-"English)."
+"Soll im ISO-639-Format mit 3 Zeichen vorliegen (z.B. <code>eng</code> für"
+" English)."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:88
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:111
 msgid "Authors"
 msgstr "Autoren"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:89
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:112
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr ""
-"Autor(en) der Ressource. Es können sowohl Personen als auch Organisationen "
-"sein."
+"Autor(en) der Ressource. Es können sowohl Personen als auch "
+"Organisationen sein."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:101
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:138
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:124
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:161
 #: reroils_data/locations/jsonschemas/locations/location-v0.0.1.json:30
 #: reroils_data/members/jsonschemas/members/member-v0.0.1.json:29
 #: reroils_data/organisations/jsonschemas/organisations/organisation-v0.0.1.json:24
@@ -312,27 +336,20 @@ msgstr ""
 msgid "Name"
 msgstr "Name"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:102
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:125
 msgid "Person's or organisation's name."
 msgstr "Name der Person oder der Organisation."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:106
-#: reroils_data/items/form_options/items/item-v0.0.1.json:84
-#: reroils_data/items/templates/reroils_data/_item_head.html:17
-#: reroils_data/patrons/templates/reroils_data/detailed_view_patrons.html:24
-msgid "Type"
-msgstr "Typ"
-
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:107
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:130
 msgid "Identify if the author is a person or an organisation."
 msgstr "Identifiziert, ob der Autor eine Person oder eine Organisation ist."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:116
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:48
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:139
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:55
 msgid "Date"
 msgstr "Datum"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:117
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:140
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -340,80 +357,80 @@ msgstr ""
 "Informationen über die Geburt und den Tod einer Person. Hilfreich, um "
 "Menschen zu unterscheiden."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:121
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:144
 msgid "Qualifier"
 msgstr "Qualifizierend"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:122
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:145
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 msgstr ""
-"Informationen über die Person (z.B. ihren Beruf). Hilfreich, um Menschen zu "
-"unterscheiden."
+"Informationen über die Person (z.B. ihren Beruf). Hilfreich, um Menschen "
+"zu unterscheiden."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:129
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:152
 msgid "Publishers"
 msgstr "Verlag"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:130
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:153
 msgid "Publisher(s) of the resource."
 msgstr "Verlag der Ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:139
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:162
 msgid "Publisher's name."
 msgstr "Verlagsname."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:148
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:171
 msgid "Place of publication"
 msgstr "Erscheinungsort"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:149
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:172
 msgid "Publisher's place of publication."
 msgstr "Erscheinungsort des Verlages."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:162
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:185
 msgid ""
-"Date of the publication. This must be an integer, ie 1989, 453, -50. Used to"
-" sort search results. Once this field is set, a free formed date of "
+"Date of the publication. This must be an integer, ie 1989, 453, -50. Used"
+" to sort search results. Once this field is set, a free formed date of "
 "publication can be added in the next field."
 msgstr ""
-"Erscheinungsdatum. Muss eine ganze Zahl sein (z.B. 1989, 453, -50). Dient "
-"zum Sortieren der Suchergebnisse. Sobald dieses Feld erfasst wurde, kann im "
-"nächsten Feld ein frei gestaltetes Erscheinungsdatum hinzugefügt werden."
+"Erscheinungsdatum. Muss eine ganze Zahl sein (z.B. 1989, 453, -50). Dient"
+" zum Sortieren der Suchergebnisse. Sobald dieses Feld erfasst wurde, kann"
+" im nächsten Feld ein frei gestaltetes Erscheinungsdatum hinzugefügt "
+"werden."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:166
-msgid ""
-"Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:189
+msgid "Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
 msgstr ""
 "Muss eine ganze Zahl sein, von -9999 bis +2050. Null-Präfixe sind nicht "
 "benötigt."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:169
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:192
 msgid "Date of publication (free formed)"
 msgstr "Erscheinungsdatum (frei gestaltet)"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:170
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:193
 msgid ""
 "Date of the publication in a free form. If there's a normalized date of "
 "publication, then a free formed date can be added to be displayed."
 msgstr ""
-"Erscheinungsdatum in freier Form. Das Feld kann nur erfasst werden, sobald "
-"das normalisiert Erscheinungsdatum angegeben ist."
+"Erscheinungsdatum in freier Form. Das Feld kann nur erfasst werden, "
+"sobald das normalisiert Erscheinungsdatum angegeben ist."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:175
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:198
 msgid "Extent"
 msgstr "Umfang"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:176
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:199
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr "Umfang der Ressource, z.B. Anzahl Seiten oder Bände"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:181
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:204
 msgid "Other Material Characteristics"
 msgstr "Andere Materialeigenschaften"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:182
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:205
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
@@ -421,148 +438,152 @@ msgstr ""
 "Andere Materialeigenschaften(z.B. Abbildungen, schwarz-weiss oder oder "
 "farbig)."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:187
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:210
 msgid "Format"
 msgstr "Format"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:188
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:211
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "Format der Ressource (z.B. Masse in cm)."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:197
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:220
 msgid "Additional materials"
 msgstr "Zusätzliche Materialien"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:198
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:221
 msgid "Accompanying material of the resource, ie maps."
 msgstr "Begleitmaterial der Ressource (z.B. Landkarten)."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:203
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:102
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:226
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:109
 msgid "Series"
 msgstr "Reihe"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:204
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:227
 msgid "Series to which belongs the resource."
 msgstr "Reihe von der Ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:216
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:239
 msgid "Title of the series."
 msgstr "Titel der Reihe."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:220
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:243
 msgid "Numbering"
 msgstr "Zählung"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:221
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:244
 msgid "Numbering of the resource within the series."
 msgstr "Zählung der Ressource innerhalb der Reihe."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:228
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:251
 msgid "Note"
 msgstr "Anmerkung"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:229
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:252
 msgid "Note on the resource."
 msgstr "Anmerkung zur Ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:238
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:63
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:261
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:70
 msgid "Abstract"
 msgstr "Abstrakt"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:239
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:262
 msgid "Abstract of the resource."
 msgstr "Abstrakt der Ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:249
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:272
 msgid "Persistent identifiers of the resource, ie reroID and ISBN."
 msgstr "Permanente Identifikatoren für die Ressource, z.B. reroID und ISBN."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:255
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:278
 msgid "reroID"
 msgstr "reroID"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:256
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:279
 msgid "Corresponding reroID of the original RERO record."
 msgstr "Entsprechende reroID des ursprünglichen RERO-Datensatzes."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:261
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:284
 msgid "bnfID"
 msgstr "bnfID"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:262
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:285
 msgid "Corresponding bnfID of the original BNF record."
 msgstr "Entsprechende bnfID des ursprünglichen BNF-Datensatzes."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:268
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:291
 msgid "ISBN of the resource."
 msgstr "ISBN der Ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:271
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:294
 msgid "Should be a valid ISBN-13 without dashes."
 msgstr "Soll eine gültige ISBN-13 Kontrollnummer ohne Bindestrich sein."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:276
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:299
 msgid "Subject"
 msgstr "Schlagwort"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:277
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:300
 msgid "Subject of the resource."
 msgstr "Schlagwort der Ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:286
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:309
 msgid "Document availability"
 msgstr "Exemplar verfügbar"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:13
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:21
 msgid "Author"
 msgstr "Autoren"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:34
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:41
 msgid "Publisher"
 msgstr "Verlag"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:80
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:87
 msgid "Physical description"
 msgstr "Physikalische Beschreibung"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:91
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:98
 msgid "Additional Materials"
 msgstr "Zusätzliche Materialien"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:120
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:127
 msgid "Uniform title"
 msgstr "Einheitstitel"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:131
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:138
+msgid "Is part of"
+msgstr ""
+
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:149
 msgid "Subjects"
 msgstr "Schlagwort"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:142
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:160
 msgid "Notes"
 msgstr "Anmerkung"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:171
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:183
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:189
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:201
 msgid "Source"
 msgstr "Herkunft"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:194
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:212
 msgid "Permalink"
 msgstr "Permalink"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:213
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:231
 msgid "Items"
 msgstr "Exemplare"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:217
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:235
 #: reroils_data/members_locations/templates/reroils_data/detailed_view_members_locations.html:61
 #: reroils_data/organisations_members/templates/reroils_data/detailed_view_organisations_members.html:38
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:230
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:248
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:28
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_head.html:15
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_personal.html:9
@@ -570,16 +591,16 @@ msgstr "Hinzufügen"
 msgid "Barcode"
 msgstr "Strichcode"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:245
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:263
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:53
 msgid "Call Number"
 msgstr "Signatur"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:256
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:274
 msgid "Library"
 msgstr "Bibliothek"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:267
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:285
 #: reroils_data/items/form_options/items/item-v0.0.1.json:76
 #: reroils_data/items/templates/reroils_data/_item_head.html:33
 #: reroils_data/locations/form_options/locations/location-v0.0.1.json:26
@@ -587,24 +608,25 @@ msgstr "Bibliothek"
 msgid "Location"
 msgstr "Standort"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:280
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:298
 msgid "Rank"
 msgstr "Position"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:292
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:310
 #: reroils_data/items/form_options/items/item-v0.0.1.json:109
+#: reroils_data/items/templates/reroils_data/_item_head.html:50
 msgid "Status"
 msgstr "Status"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:307
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:325
 msgid "Request"
 msgstr "Bestellung"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:311
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:329
 msgid "Available Pickup Locations"
 msgstr "Verfügbare Abholungsorte"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:341
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:359
 msgid "Export Formats"
 msgstr "Exportformate"
 
@@ -665,6 +687,7 @@ msgid "Barcode of the item."
 msgstr "Strichcode des Exemplars."
 
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:34
+#: reroils_data/items/templates/reroils_data/_item_head.html:9
 msgid "Call number"
 msgstr "Signatur"
 
@@ -695,10 +718,6 @@ msgstr "Anzahl der Verlängerungen"
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:86
 msgid "Item renewal count."
 msgstr "Anzahl der Exemplarerneuerungen."
-
-#: reroils_data/items/templates/reroils_data/_item_head.html:9
-msgid "Callnumber"
-msgstr "Signatur"
 
 #: reroils_data/items/templates/reroils_data/_item_head.html:25
 msgid "Document"
@@ -953,7 +972,8 @@ msgstr "Erforderlich. Sollte ISO 8601 sein, JJJJ-MM-TT."
 #: reroils_data/patrons/jsonschemas/patrons/patron-v0.0.1.json:54
 msgid "Email should have at least one <code>@</code> and one <code>.</code>"
 msgstr ""
-"E-Mail sollte mindestens ein <code>@</code> und einen <code>.</code> haben."
+"E-Mail sollte mindestens ein <code>@</code> und einen <code>.</code> "
+"haben."
 
 #: reroils_data/patrons/jsonschemas/patrons/patron-v0.0.1.json:57
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_personal.html:20
@@ -995,7 +1015,8 @@ msgstr "Telefonnummer mit internationaler Anzeige, ohne Leerzeichen."
 
 #: reroils_data/patrons/jsonschemas/patrons/patron-v0.0.1.json:80
 msgid ""
-"Phone number with the international prefix, without spaces, ie +41221234567."
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr ""
 "Telefonnummer mit der internationalen Anzeige, ohne Leerzeichen, z.B. "
 "+41221234567."
@@ -1077,3 +1098,7 @@ msgstr "Keine Bestellung"
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:56
 msgid "Belongs to"
 msgstr "Gehört"
+
+#~ msgid "Callnumber"
+#~ msgstr "Signatur"
+

--- a/reroils_data/translations/en/LC_MESSAGES/messages.po
+++ b/reroils_data/translations/en/LC_MESSAGES/messages.po
@@ -1,9 +1,9 @@
-# Translations template for reroils-data.
+# English translations for reroils-data.
 # Copyright (C) 2018 RERO
 # This file is distributed under the same license as the reroils-data
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 # Translators:
 # iGor milhit <igor.milhit@rero.ch>, 2018
 # Nicolas Labat <n-labat@hotmail.com>, 2018
@@ -11,16 +11,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: reroils-data 0.1.0a13\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2018-06-26 10:22+0200\n"
+"POT-Creation-Date: 2018-08-10 07:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Nicolas Labat <n-labat@hotmail.com>, 2018\n"
+"Language: en\n"
 "Language-Team: English (https://www.transifex.com/rero/teams/77935/en/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
-"Language: en\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. NOTE: This is a note to a translator.
 #: reroils_data/ext.py:43
@@ -32,20 +32,20 @@ msgid "available"
 msgstr "available"
 
 #: reroils_data/filter.py:68
+msgid "on_site consultation"
+msgstr "on-site consultation"
+
+#: reroils_data/filter.py:70
 msgid "not available"
 msgstr "not available"
 
-#: reroils_data/filter.py:75
+#: reroils_data/filter.py:77
 msgid "due until"
 msgstr "due until"
 
-#: reroils_data/filter.py:77
+#: reroils_data/filter.py:79
 msgid "requested"
 msgstr "requested"
-
-#: reroils_data/filter.py:81
-msgid "on_site consultation"
-msgstr "on-site consultation"
 
 #: reroils_data/documents/views.py:63
 msgid "The record has been imported."
@@ -103,12 +103,12 @@ msgid "Submit"
 msgstr "Submit"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:26
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:248
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:271
 msgid "Identifiers"
 msgstr "Identifiers"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:38
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:20
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:21
 msgid "Document ID"
 msgstr "Document ID"
 
@@ -117,8 +117,8 @@ msgid "Persistent identifier, automatically generated."
 msgstr "Persistent identifier, automatically generated."
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:50
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:267
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:159
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:290
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:177
 msgid "ISBN"
 msgstr "ISBN"
 
@@ -127,8 +127,8 @@ msgid "Import"
 msgstr "Import"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:77
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:25
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:215
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:42
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:238
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:52
 msgid "Title"
 msgstr "Title"
@@ -217,15 +217,15 @@ msgid "Spanish"
 msgstr "Spanish"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:215
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:161
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:184
 msgid "Date of publication"
 msgstr "Date of publication"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:3
-msgid "Schema for book"
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:3
+msgid "Schema for document"
 msgstr "Schema for book"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:14
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:15
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:17
 #: reroils_data/locations/jsonschemas/locations/location-v0.0.1.json:15
 #: reroils_data/members/jsonschemas/members/member-v0.0.1.json:14
@@ -234,20 +234,36 @@ msgstr "Schema for book"
 msgid "Schema"
 msgstr "Schema"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:15
-msgid "Schema to validate book document against."
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:16
+msgid "Schema to validate document against."
 msgstr "Schema to validate book document against."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:26
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:27
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:26
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:129
+#: reroils_data/items/form_options/items/item-v0.0.1.json:84
+#: reroils_data/items/templates/reroils_data/_item_head.html:17
+#: reroils_data/patrons/templates/reroils_data/detailed_view_patrons.html:24
+msgid "Type"
+msgstr "Type"
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:27
+msgid "Document type."
+msgstr "Document at desk"
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:29
+msgid "Required. Type of the document. Should be selected in the list below."
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:43
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:44
 msgid "Required. Entire title without statement of responsibility."
 msgstr "Required. Entire title without statement of responsibility."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:32
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:49
 msgid "Proper or uniformed title"
 msgstr "Proper or uniformed title"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:33
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:50
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
@@ -255,49 +271,57 @@ msgstr ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:42
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:59
+msgid "Is part of"
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:60
+msgid "Title of the host document."
+msgstr "Title of the series."
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:65
 msgid "Languages"
 msgstr "Languages"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:43
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:66
 msgid "List of languages for the resource."
 msgstr "List of languages for the resource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:54
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:77
 msgid "Language"
 msgstr "Language"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:55
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:57
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:78
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:80
 msgid "Required. Language of the resource, primary or not."
 msgstr "Required. Language of the resource, primary or not."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:77
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:100
 msgid "Translated from"
 msgstr "Translated from"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:78
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:101
 msgid "Language from which a resource is translated."
 msgstr "Language from which a resource is translated."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:84
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:107
 msgid ""
-"Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> for "
-"English."
+"Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> "
+"for English."
 msgstr ""
-"Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> for "
-"English."
+"Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> "
+"for English."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:88
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:111
 msgid "Authors"
 msgstr "Authors"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:89
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:112
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "Author(s) of the resource. Can be either persons or organisations."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:101
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:138
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:124
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:161
 #: reroils_data/locations/jsonschemas/locations/location-v0.0.1.json:30
 #: reroils_data/members/jsonschemas/members/member-v0.0.1.json:29
 #: reroils_data/organisations/jsonschemas/organisations/organisation-v0.0.1.json:24
@@ -306,27 +330,20 @@ msgstr "Author(s) of the resource. Can be either persons or organisations."
 msgid "Name"
 msgstr "Name"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:102
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:125
 msgid "Person's or organisation's name."
 msgstr "Person's or organisation's name."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:106
-#: reroils_data/items/form_options/items/item-v0.0.1.json:84
-#: reroils_data/items/templates/reroils_data/_item_head.html:17
-#: reroils_data/patrons/templates/reroils_data/detailed_view_patrons.html:24
-msgid "Type"
-msgstr "Type"
-
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:107
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:130
 msgid "Identify if the author is a person or an organisation."
 msgstr "Identify if the author is a person or an organisation."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:116
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:48
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:139
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:55
 msgid "Date"
 msgstr "Date"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:117
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:140
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
@@ -334,11 +351,11 @@ msgstr ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:121
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:144
 msgid "Qualifier"
 msgstr "Qualifier"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:122
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:145
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
@@ -346,47 +363,45 @@ msgstr ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:129
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:152
 msgid "Publishers"
 msgstr "Publishers"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:130
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:153
 msgid "Publisher(s) of the resource."
 msgstr "Publisher(s) of the resource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:139
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:162
 msgid "Publisher's name."
 msgstr "Publisher's name."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:148
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:171
 msgid "Place of publication"
 msgstr "Place of publication"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:149
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:172
 msgid "Publisher's place of publication."
 msgstr "Publisher's place of publication."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:162
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:185
 msgid ""
-"Date of the publication. This must be an integer, ie 1989, 453, -50. Used to"
-" sort search results. Once this field is set, a free formed date of "
+"Date of the publication. This must be an integer, ie 1989, 453, -50. Used"
+" to sort search results. Once this field is set, a free formed date of "
 "publication can be added in the next field."
 msgstr ""
-"Date of the publication. This must be an integer, ie 1989, 453, -50. Used to"
-" sort search results. Once this field is set, a free formed date of "
+"Date of the publication. This must be an integer, ie 1989, 453, -50. Used"
+" to sort search results. Once this field is set, a free formed date of "
 "publication can be added in the next field."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:166
-msgid ""
-"Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
-msgstr ""
-"Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:189
+msgid "Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
+msgstr "Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:169
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:192
 msgid "Date of publication (free formed)"
 msgstr "Date of publication (free formed)"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:170
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:193
 msgid ""
 "Date of the publication in a free form. If there's a normalized date of "
 "publication, then a free formed date can be added to be displayed."
@@ -394,19 +409,19 @@ msgstr ""
 "Date of the publication in a free form. If there's a normalized date of "
 "publication, then a free formed date can be added to be displayed."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:175
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:198
 msgid "Extent"
 msgstr "Extent"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:176
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:199
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr "Extent of the resource, ie number of pages or volumes."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:181
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:204
 msgid "Other Material Characteristics"
 msgstr "Other Material Characteristics"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:182
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:205
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
@@ -414,148 +429,152 @@ msgstr ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:187
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:210
 msgid "Format"
 msgstr "Format"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:188
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:211
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "Format of the resource, ie dimensions in cm."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:197
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:220
 msgid "Additional materials"
 msgstr "Additional materials"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:198
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:221
 msgid "Accompanying material of the resource, ie maps."
 msgstr "Accompanying material of the resource, ie maps."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:203
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:102
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:226
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:109
 msgid "Series"
 msgstr "Series"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:204
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:227
 msgid "Series to which belongs the resource."
 msgstr "Series to which belongs the resource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:216
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:239
 msgid "Title of the series."
 msgstr "Title of the series."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:220
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:243
 msgid "Numbering"
 msgstr "Numbering"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:221
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:244
 msgid "Numbering of the resource within the series."
 msgstr "Numbering of the resource within the series."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:228
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:251
 msgid "Note"
 msgstr "Note"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:229
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:252
 msgid "Note on the resource."
 msgstr "Note on the resource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:238
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:63
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:261
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:70
 msgid "Abstract"
 msgstr "Abstract"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:239
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:262
 msgid "Abstract of the resource."
 msgstr "Abstract of the resource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:249
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:272
 msgid "Persistent identifiers of the resource, ie reroID and ISBN."
 msgstr "Persistent identifiers of the resource, ie reroID and ISBN."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:255
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:278
 msgid "reroID"
 msgstr "reroID"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:256
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:279
 msgid "Corresponding reroID of the original RERO record."
 msgstr "Corresponding reroID of the original RERO record."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:261
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:284
 msgid "bnfID"
 msgstr "bnfID"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:262
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:285
 msgid "Corresponding bnfID of the original BNF record."
 msgstr "Corresponding bnfID of the original BNF record."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:268
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:291
 msgid "ISBN of the resource."
 msgstr "ISBN of the resource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:271
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:294
 msgid "Should be a valid ISBN-13 without dashes."
 msgstr "Should be a valid ISBN-13 without dashes."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:276
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:299
 msgid "Subject"
 msgstr "Subject"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:277
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:300
 msgid "Subject of the resource."
 msgstr "Subject of the resource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:286
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:309
 msgid "Document availability"
 msgstr "Document availability"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:13
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:21
 msgid "Author"
 msgstr "Author"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:34
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:41
 msgid "Publisher"
 msgstr "Publisher"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:80
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:87
 msgid "Physical description"
 msgstr "Physical description"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:91
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:98
 msgid "Additional Materials"
 msgstr "Additional Materials"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:120
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:127
 msgid "Uniform title"
 msgstr "Uniform title"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:131
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:138
+msgid "Is part of"
+msgstr ""
+
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:149
 msgid "Subjects"
 msgstr "Subjects"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:142
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:160
 msgid "Notes"
 msgstr "Notes"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:171
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:183
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:189
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:201
 msgid "Source"
 msgstr "Source"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:194
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:212
 msgid "Permalink"
 msgstr "Permalink"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:213
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:231
 msgid "Items"
 msgstr "Items"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:217
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:235
 #: reroils_data/members_locations/templates/reroils_data/detailed_view_members_locations.html:61
 #: reroils_data/organisations_members/templates/reroils_data/detailed_view_organisations_members.html:38
 msgid "Add"
 msgstr "Add"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:230
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:248
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:28
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_head.html:15
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_personal.html:9
@@ -563,16 +582,16 @@ msgstr "Add"
 msgid "Barcode"
 msgstr "Barcode"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:245
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:263
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:53
 msgid "Call Number"
 msgstr "Call Number"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:256
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:274
 msgid "Library"
 msgstr "Library"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:267
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:285
 #: reroils_data/items/form_options/items/item-v0.0.1.json:76
 #: reroils_data/items/templates/reroils_data/_item_head.html:33
 #: reroils_data/locations/form_options/locations/location-v0.0.1.json:26
@@ -580,24 +599,25 @@ msgstr "Library"
 msgid "Location"
 msgstr "Location"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:280
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:298
 msgid "Rank"
 msgstr "Your position on the waiting list"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:292
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:310
 #: reroils_data/items/form_options/items/item-v0.0.1.json:109
+#: reroils_data/items/templates/reroils_data/_item_head.html:50
 msgid "Status"
 msgstr "Status"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:307
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:325
 msgid "Request"
 msgstr "Request"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:311
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:329
 msgid "Available Pickup Locations"
 msgstr "Available Pickup Locations"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:341
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:359
 msgid "Export Formats"
 msgstr "Export Formats"
 
@@ -658,6 +678,7 @@ msgid "Barcode of the item."
 msgstr "Barcode of the item."
 
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:34
+#: reroils_data/items/templates/reroils_data/_item_head.html:9
 msgid "Call number"
 msgstr "Call number"
 
@@ -688,10 +709,6 @@ msgstr "Renewal count"
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:86
 msgid "Item renewal count."
 msgstr "Item renewal count."
-
-#: reroils_data/items/templates/reroils_data/_item_head.html:9
-msgid "Callnumber"
-msgstr "Call number"
 
 #: reroils_data/items/templates/reroils_data/_item_head.html:25
 msgid "Document"
@@ -987,9 +1004,11 @@ msgstr "Phone number with the international prefix, without spaces."
 
 #: reroils_data/patrons/jsonschemas/patrons/patron-v0.0.1.json:80
 msgid ""
-"Phone number with the international prefix, without spaces, ie +41221234567."
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr ""
-"Phone number with the international prefix, without spaces, ie +41221234567."
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 
 #: reroils_data/patrons/jsonschemas/patrons/patron-v0.0.1.json:83
 msgid "Patron's type"
@@ -1068,3 +1087,7 @@ msgstr "No pending"
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:56
 msgid "Belongs to"
 msgstr "Belongs to"
+
+#~ msgid "Callnumber"
+#~ msgstr "Call number"
+

--- a/reroils_data/translations/fr/LC_MESSAGES/messages.po
+++ b/reroils_data/translations/fr/LC_MESSAGES/messages.po
@@ -1,9 +1,9 @@
-# Translations template for reroils-data.
+# French translations for reroils-data.
 # Copyright (C) 2018 RERO
 # This file is distributed under the same license as the reroils-data
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 # Translators:
 # Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2018
 # iGor milhit <igor.milhit@rero.ch>, 2018
@@ -12,16 +12,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: reroils-data 0.1.0a13\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2018-06-26 10:22+0200\n"
+"POT-Creation-Date: 2018-08-10 07:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Nicolas Labat <n-labat@hotmail.com>, 2018\n"
+"Language: fr\n"
 "Language-Team: French (https://www.transifex.com/rero/teams/77935/fr/)\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
-"Language: fr\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. NOTE: This is a note to a translator.
 #: reroils_data/ext.py:43
@@ -33,20 +33,20 @@ msgid "available"
 msgstr "disponible"
 
 #: reroils_data/filter.py:68
+msgid "on_site consultation"
+msgstr "consultation sur place"
+
+#: reroils_data/filter.py:70
 msgid "not available"
 msgstr "non disponible"
 
-#: reroils_data/filter.py:75
+#: reroils_data/filter.py:77
 msgid "due until"
 msgstr "à rendre le"
 
-#: reroils_data/filter.py:77
+#: reroils_data/filter.py:79
 msgid "requested"
 msgstr "demandé"
-
-#: reroils_data/filter.py:81
-msgid "on_site consultation"
-msgstr "consultation sur place"
 
 #: reroils_data/documents/views.py:63
 msgid "The record has been imported."
@@ -104,12 +104,12 @@ msgid "Submit"
 msgstr "Soumettre"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:26
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:248
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:271
 msgid "Identifiers"
 msgstr "Identifiants"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:38
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:20
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:21
 msgid "Document ID"
 msgstr "ID du document"
 
@@ -118,8 +118,8 @@ msgid "Persistent identifier, automatically generated."
 msgstr "Identifiant persistant, généré automatiquement."
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:50
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:267
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:159
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:290
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:177
 msgid "ISBN"
 msgstr "ISBN"
 
@@ -128,8 +128,8 @@ msgid "Import"
 msgstr "Importer"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:77
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:25
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:215
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:42
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:238
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:52
 msgid "Title"
 msgstr "Titre"
@@ -218,15 +218,15 @@ msgid "Spanish"
 msgstr "Espagnol"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:215
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:161
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:184
 msgid "Date of publication"
 msgstr "Date de publication"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:3
-msgid "Schema for book"
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:3
+msgid "Schema for document"
 msgstr "Schéma pour un livre"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:14
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:15
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:17
 #: reroils_data/locations/jsonschemas/locations/location-v0.0.1.json:15
 #: reroils_data/members/jsonschemas/members/member-v0.0.1.json:14
@@ -235,73 +235,96 @@ msgstr "Schéma pour un livre"
 msgid "Schema"
 msgstr "Schéma"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:15
-msgid "Schema to validate book document against."
-msgstr ""
-"Schéma de validation des notices bibliographiques de type monographies."
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:16
+msgid "Schema to validate document against."
+msgstr "Schéma de validation des notices bibliographiques de type monographies."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:26
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:27
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:26
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:129
+#: reroils_data/items/form_options/items/item-v0.0.1.json:84
+#: reroils_data/items/templates/reroils_data/_item_head.html:17
+#: reroils_data/patrons/templates/reroils_data/detailed_view_patrons.html:24
+msgid "Type"
+msgstr "Type"
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:27
+msgid "Document type."
+msgstr "Document au bureau de prêt"
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:29
+msgid "Required. Type of the document. Should be selected in the list below."
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:43
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:44
 msgid "Required. Entire title without statement of responsibility."
 msgstr "Requis. Titre complet sans mention de responsabilité."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:32
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:49
 msgid "Proper or uniformed title"
 msgstr "Titre uniforme"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:33
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:50
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
 msgstr ""
-"Titre uniforme, un titre associé ou analytique, contrôlé par un fichier ou "
-"une liste d'autorités, et utilisé comme point d'accès supplémentaire."
+"Titre uniforme, un titre associé ou analytique, contrôlé par un fichier "
+"ou une liste d'autorités, et utilisé comme point d'accès supplémentaire."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:42
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:59
+msgid "Is part of"
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:60
+msgid "Title of the host document."
+msgstr "Titre de la collection."
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:65
 msgid "Languages"
 msgstr "Langues"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:43
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:66
 msgid "List of languages for the resource."
 msgstr "Listes des langues de la ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:54
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:77
 msgid "Language"
 msgstr "Langue"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:55
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:57
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:78
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:80
 msgid "Required. Language of the resource, primary or not."
 msgstr "Requis. Langue de la ressource, principale ou secondaire."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:77
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:100
 msgid "Translated from"
 msgstr "Traduit de"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:78
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:101
 msgid "Language from which a resource is translated."
 msgstr "Langue de laquelle la ressource a été traduite."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:84
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:107
 msgid ""
-"Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> for "
-"English."
+"Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> "
+"for English."
 msgstr ""
 "Doit être dans le format ISO 639, en 3 caractères, par exemple "
 "<code>eng</code> pour l'anglais."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:88
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:111
 msgid "Authors"
 msgstr "Auteurs"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:89
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:112
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr ""
 "Auteur(s) de la ressource. Peut être soit une personne soit une "
 "collectivité."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:101
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:138
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:124
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:161
 #: reroils_data/locations/jsonschemas/locations/location-v0.0.1.json:30
 #: reroils_data/members/jsonschemas/members/member-v0.0.1.json:29
 #: reroils_data/organisations/jsonschemas/organisations/organisation-v0.0.1.json:24
@@ -310,263 +333,257 @@ msgstr ""
 msgid "Name"
 msgstr "Nom"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:102
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:125
 msgid "Person's or organisation's name."
 msgstr "Nom de la personne ou de la collectivité."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:106
-#: reroils_data/items/form_options/items/item-v0.0.1.json:84
-#: reroils_data/items/templates/reroils_data/_item_head.html:17
-#: reroils_data/patrons/templates/reroils_data/detailed_view_patrons.html:24
-msgid "Type"
-msgstr "Type"
-
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:107
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:130
 msgid "Identify if the author is a person or an organisation."
 msgstr "Identifie si l'auteur est une personne ou une collectivité."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:116
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:48
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:139
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:55
 msgid "Date"
 msgstr "Date"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:117
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:140
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 msgstr ""
-"Informations sur les dates de naissance et de décès d'une personne. Utile "
-"pour distinguer les homonymes."
+"Informations sur les dates de naissance et de décès d'une personne. Utile"
+" pour distinguer les homonymes."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:121
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:144
 msgid "Qualifier"
 msgstr "Qualificatif"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:122
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:145
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 msgstr ""
-"Informations qualifiant la personne, par exemple sa profession. Utile pour "
-"distinguer les homonymes."
+"Informations qualifiant la personne, par exemple sa profession. Utile "
+"pour distinguer les homonymes."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:129
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:152
 msgid "Publishers"
 msgstr "Editeurs"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:130
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:153
 msgid "Publisher(s) of the resource."
 msgstr "Editeur(s) de la ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:139
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:162
 msgid "Publisher's name."
 msgstr "Nom de l'éditeur."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:148
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:171
 msgid "Place of publication"
 msgstr "Lieu de publication"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:149
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:172
 msgid "Publisher's place of publication."
 msgstr "Lieu de publication de l'éditeur."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:162
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:185
 msgid ""
-"Date of the publication. This must be an integer, ie 1989, 453, -50. Used to"
-" sort search results. Once this field is set, a free formed date of "
+"Date of the publication. This must be an integer, ie 1989, 453, -50. Used"
+" to sort search results. Once this field is set, a free formed date of "
 "publication can be added in the next field."
 msgstr ""
 "Date de publication. Doit être un chiffre, par exemple 1989, 453, -50. "
 "Utilisée pour filtrer les résultats de recherche. Une fois le champ "
-"renseigné, une date de publication sous forme libre peut être ajoutée dans "
-"le champ suivant."
+"renseigné, une date de publication sous forme libre peut être ajoutée "
+"dans le champ suivant."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:166
-msgid ""
-"Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
-msgstr ""
-"Doit être un chiffre, de -9999 à +2050. Aucun préfixe n'est nécessaire."
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:189
+msgid "Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
+msgstr "Doit être un chiffre, de -9999 à +2050. Aucun préfixe n'est nécessaire."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:169
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:192
 msgid "Date of publication (free formed)"
 msgstr "Date de publication (forme libre)"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:170
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:193
 msgid ""
 "Date of the publication in a free form. If there's a normalized date of "
 "publication, then a free formed date can be added to be displayed."
 msgstr ""
-"Date de publication sous forme libre. S'il existe une date de publication "
-"sous forme normalisée, une date sous forme libre peut être ajoutée et "
+"Date de publication sous forme libre. S'il existe une date de publication"
+" sous forme normalisée, une date sous forme libre peut être ajoutée et "
 "affichée."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:175
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:198
 msgid "Extent"
 msgstr "Importance matérielle"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:176
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:199
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr ""
-"Importance matérielle de la ressource, par exemple le nombre de pages ou de "
-"volumes."
+"Importance matérielle de la ressource, par exemple le nombre de pages ou "
+"de volumes."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:181
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:204
 msgid "Other Material Characteristics"
 msgstr "Autres caractéristiques matérielles"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:182
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:205
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
 msgstr ""
-"Autres caractéristiques matérielles, par exemple des illustrations, noir et "
-"blanc ou en couleurs."
+"Autres caractéristiques matérielles, par exemple des illustrations, noir "
+"et blanc ou en couleurs."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:187
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:210
 msgid "Format"
 msgstr "Format"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:188
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:211
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "Format de la ressource, par exemple les dimensions en cm."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:197
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:220
 msgid "Additional materials"
 msgstr "Matériel d'accompagnement"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:198
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:221
 msgid "Accompanying material of the resource, ie maps."
 msgstr ""
 "Matériel d'accompagnement de la ressource, par exemple des cartes "
 "géographiques."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:203
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:102
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:226
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:109
 msgid "Series"
 msgstr "Collection"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:204
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:227
 msgid "Series to which belongs the resource."
 msgstr "Collection à laquelle appartient la ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:216
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:239
 msgid "Title of the series."
 msgstr "Titre de la collection."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:220
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:243
 msgid "Numbering"
 msgstr "Numérotation"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:221
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:244
 msgid "Numbering of the resource within the series."
 msgstr "Numérotation de la ressource au sein de la collection."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:228
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:251
 msgid "Note"
 msgstr "Note"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:229
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:252
 msgid "Note on the resource."
 msgstr "Note sur la ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:238
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:63
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:261
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:70
 msgid "Abstract"
 msgstr "Résumé"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:239
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:262
 msgid "Abstract of the resource."
 msgstr "Résumé de la ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:249
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:272
 msgid "Persistent identifiers of the resource, ie reroID and ISBN."
-msgstr ""
-"Identifiants pérennes de la ressource, par exemple le reroID et l'ISBN."
+msgstr "Identifiants pérennes de la ressource, par exemple le reroID et l'ISBN."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:255
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:278
 msgid "reroID"
 msgstr "reroID"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:256
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:279
 msgid "Corresponding reroID of the original RERO record."
 msgstr "reroID correspondant de la notice bibliographique RERO d'origine."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:261
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:284
 msgid "bnfID"
 msgstr "bnfID"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:262
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:285
 msgid "Corresponding bnfID of the original BNF record."
 msgstr "bnfID correspondant de la notice bibliographique BNF d'origine."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:268
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:291
 msgid "ISBN of the resource."
 msgstr "ISBN de la ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:271
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:294
 msgid "Should be a valid ISBN-13 without dashes."
 msgstr "Doit être un ISBN-13 valide sans traits d'union."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:276
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:299
 msgid "Subject"
 msgstr "Sujet"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:277
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:300
 msgid "Subject of the resource."
 msgstr "Sujet de la ressource."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:286
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:309
 msgid "Document availability"
 msgstr "Disponibilité du document"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:13
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:21
 msgid "Author"
 msgstr "Auteurs"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:34
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:41
 msgid "Publisher"
 msgstr "Editeurs"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:80
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:87
 msgid "Physical description"
 msgstr "Description matérielle"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:91
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:98
 msgid "Additional Materials"
 msgstr "Matériel d'accompagnement"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:120
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:127
 msgid "Uniform title"
 msgstr "Titre uniforme"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:131
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:138
+msgid "Is part of"
+msgstr ""
+
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:149
 msgid "Subjects"
 msgstr "Sujet"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:142
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:160
 msgid "Notes"
 msgstr "Notes"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:171
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:183
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:189
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:201
 msgid "Source"
 msgstr "Source"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:194
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:212
 msgid "Permalink"
 msgstr "Permalien"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:213
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:231
 msgid "Items"
 msgstr "Exemplaires"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:217
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:235
 #: reroils_data/members_locations/templates/reroils_data/detailed_view_members_locations.html:61
 #: reroils_data/organisations_members/templates/reroils_data/detailed_view_organisations_members.html:38
 msgid "Add"
 msgstr "Ajouter"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:230
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:248
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:28
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_head.html:15
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_personal.html:9
@@ -574,16 +591,16 @@ msgstr "Ajouter"
 msgid "Barcode"
 msgstr "Code-barre"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:245
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:263
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:53
 msgid "Call Number"
 msgstr "Cote"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:256
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:274
 msgid "Library"
 msgstr "Bibliothèque"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:267
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:285
 #: reroils_data/items/form_options/items/item-v0.0.1.json:76
 #: reroils_data/items/templates/reroils_data/_item_head.html:33
 #: reroils_data/locations/form_options/locations/location-v0.0.1.json:26
@@ -591,24 +608,25 @@ msgstr "Bibliothèque"
 msgid "Location"
 msgstr "Localisation"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:280
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:298
 msgid "Rank"
 msgstr "Position dans la liste"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:292
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:310
 #: reroils_data/items/form_options/items/item-v0.0.1.json:109
+#: reroils_data/items/templates/reroils_data/_item_head.html:50
 msgid "Status"
 msgstr "Statut"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:307
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:325
 msgid "Request"
 msgstr "Demander"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:311
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:329
 msgid "Available Pickup Locations"
 msgstr "Lieux de retrait disponibles"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:341
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:359
 msgid "Export Formats"
 msgstr "Formats d'export"
 
@@ -669,6 +687,7 @@ msgid "Barcode of the item."
 msgstr "Code-barres de l'exemplaire."
 
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:34
+#: reroils_data/items/templates/reroils_data/_item_head.html:9
 msgid "Call number"
 msgstr "Cote"
 
@@ -699,10 +718,6 @@ msgstr "Nombre de prolongation(s)"
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:86
 msgid "Item renewal count."
 msgstr "Nombre de prolongation de l'exemplaire."
-
-#: reroils_data/items/templates/reroils_data/_item_head.html:9
-msgid "Callnumber"
-msgstr "Cote"
 
 #: reroils_data/items/templates/reroils_data/_item_head.html:25
 msgid "Document"
@@ -956,8 +971,7 @@ msgstr "Obligatoire. Doit être au format ISO 8601, AAAA-MM-JJ."
 
 #: reroils_data/patrons/jsonschemas/patrons/patron-v0.0.1.json:54
 msgid "Email should have at least one <code>@</code> and one <code>.</code>"
-msgstr ""
-"L'email doit comporter au moins un <code>@</code> et un <code>.</code>"
+msgstr "L'email doit comporter au moins un <code>@</code> et un <code>.</code>"
 
 #: reroils_data/patrons/jsonschemas/patrons/patron-v0.0.1.json:57
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_personal.html:20
@@ -999,7 +1013,8 @@ msgstr "Numéro de téléphone avec l'indicatif international, sans espaces."
 
 #: reroils_data/patrons/jsonschemas/patrons/patron-v0.0.1.json:80
 msgid ""
-"Phone number with the international prefix, without spaces, ie +41221234567."
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr ""
 "Numéro de téléphone avec l'indicatif international, sans espaces, ex: "
 "+41221234567."
@@ -1081,3 +1096,7 @@ msgstr "Aucune réservation"
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:56
 msgid "Belongs to"
 msgstr "Appartient à"
+
+#~ msgid "Callnumber"
+#~ msgstr "Cote"
+

--- a/reroils_data/translations/it/LC_MESSAGES/messages.po
+++ b/reroils_data/translations/it/LC_MESSAGES/messages.po
@@ -1,9 +1,9 @@
-# Translations template for reroils-data.
+# Italian translations for reroils-data.
 # Copyright (C) 2018 RERO
 # This file is distributed under the same license as the reroils-data
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 # Translators:
 # iGor milhit <igor.milhit@rero.ch>, 2018
 # Gianni Pante <gianni.pante@rero.ch>, 2018
@@ -13,16 +13,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: reroils-data 0.1.0a13\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2018-06-26 10:22+0200\n"
+"POT-Creation-Date: 2018-08-10 07:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Johnny Mariéthoz <johnny.mariethoz@rero.ch>, 2018\n"
+"Language: it\n"
 "Language-Team: Italian (https://www.transifex.com/rero/teams/77935/it/)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
-"Language: it\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. NOTE: This is a note to a translator.
 #: reroils_data/ext.py:43
@@ -34,20 +34,20 @@ msgid "available"
 msgstr "disponibile"
 
 #: reroils_data/filter.py:68
+msgid "on_site consultation"
+msgstr "consultazione in loco"
+
+#: reroils_data/filter.py:70
 msgid "not available"
 msgstr "indisponibile"
 
-#: reroils_data/filter.py:75
+#: reroils_data/filter.py:77
 msgid "due until"
 msgstr "in scadenza fino al"
 
-#: reroils_data/filter.py:77
+#: reroils_data/filter.py:79
 msgid "requested"
 msgstr "richiesto"
-
-#: reroils_data/filter.py:81
-msgid "on_site consultation"
-msgstr "consultazione in loco"
 
 #: reroils_data/documents/views.py:63
 msgid "The record has been imported."
@@ -105,12 +105,12 @@ msgid "Submit"
 msgstr "Sottoporre"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:26
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:248
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:271
 msgid "Identifiers"
 msgstr "Identificatori"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:38
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:20
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:21
 msgid "Document ID"
 msgstr "Documento ID"
 
@@ -119,8 +119,8 @@ msgid "Persistent identifier, automatically generated."
 msgstr "Identifiant perenne generato automaticamente."
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:50
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:267
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:159
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:290
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:177
 msgid "ISBN"
 msgstr "ISBN"
 
@@ -129,8 +129,8 @@ msgid "Import"
 msgstr "Importare"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:77
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:25
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:215
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:42
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:238
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:52
 msgid "Title"
 msgstr "Titolo"
@@ -219,15 +219,15 @@ msgid "Spanish"
 msgstr "Spagnolo"
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:215
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:161
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:184
 msgid "Date of publication"
 msgstr "Data di pubblicazione"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:3
-msgid "Schema for book"
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:3
+msgid "Schema for document"
 msgstr "Schema per un libro"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:14
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:15
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:17
 #: reroils_data/locations/jsonschemas/locations/location-v0.0.1.json:15
 #: reroils_data/members/jsonschemas/members/member-v0.0.1.json:14
@@ -236,71 +236,95 @@ msgstr "Schema per un libro"
 msgid "Schema"
 msgstr "Schema"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:15
-msgid "Schema to validate book document against."
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:16
+msgid "Schema to validate document against."
 msgstr "Schema di convalida per record bibliografichi di tipo monografico."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:26
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:27
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:26
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:129
+#: reroils_data/items/form_options/items/item-v0.0.1.json:84
+#: reroils_data/items/templates/reroils_data/_item_head.html:17
+#: reroils_data/patrons/templates/reroils_data/detailed_view_patrons.html:24
+msgid "Type"
+msgstr "Typo"
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:27
+msgid "Document type."
+msgstr "Documento al banco prestiti"
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:29
+msgid "Required. Type of the document. Should be selected in the list below."
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:43
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:44
 msgid "Required. Entire title without statement of responsibility."
 msgstr "Richiesto. Titolo completo senza dichiarazione di responsabilità."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:32
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:49
 msgid "Proper or uniformed title"
 msgstr "Titolo uniforme"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:33
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:50
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
 msgstr ""
 "Titolo uniforme, un titolo associato o analitico, controllato da un "
-"fascicolo o da un elenco di autorità e utilizzato come ulteriore punto di "
-"accesso."
+"fascicolo o da un elenco di autorità e utilizzato come ulteriore punto di"
+" accesso."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:42
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:59
+msgid "Is part of"
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:60
+msgid "Title of the host document."
+msgstr "Titolo della collezione."
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:65
 msgid "Languages"
 msgstr "Lingua"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:43
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:66
 msgid "List of languages for the resource."
 msgstr "Elenchi linguistici dell'opera."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:54
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:77
 msgid "Language"
 msgstr "Lingua"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:55
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:57
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:78
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:80
 msgid "Required. Language of the resource, primary or not."
 msgstr "Richiesto. Lingua dell'opera', primaria o secondaria."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:77
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:100
 msgid "Translated from"
 msgstr "Tradotto da"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:78
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:101
 msgid "Language from which a resource is translated."
 msgstr "Lingua da cui l'opera è stata tradotta."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:84
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:107
 msgid ""
-"Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> for "
-"English."
+"Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> "
+"for English."
 msgstr ""
-"Deve essere in formato ISO 639, in 3 caratteri, ad esempio <code>eng</code> "
-"per l'inglese."
+"Deve essere in formato ISO 639, in 3 caratteri, ad esempio "
+"<code>eng</code> per l'inglese."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:88
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:111
 msgid "Authors"
 msgstr "Autore o autori"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:89
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:112
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr "Autore o autori dell'opera. Può essere una persona o un ente."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:101
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:138
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:124
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:161
 #: reroils_data/locations/jsonschemas/locations/location-v0.0.1.json:30
 #: reroils_data/members/jsonschemas/members/member-v0.0.1.json:29
 #: reroils_data/organisations/jsonschemas/organisations/organisation-v0.0.1.json:24
@@ -309,258 +333,253 @@ msgstr "Autore o autori dell'opera. Può essere una persona o un ente."
 msgid "Name"
 msgstr "Nome"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:102
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:125
 msgid "Person's or organisation's name."
 msgstr "Nome della persona o dell'ente."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:106
-#: reroils_data/items/form_options/items/item-v0.0.1.json:84
-#: reroils_data/items/templates/reroils_data/_item_head.html:17
-#: reroils_data/patrons/templates/reroils_data/detailed_view_patrons.html:24
-msgid "Type"
-msgstr "Typo"
-
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:107
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:130
 msgid "Identify if the author is a person or an organisation."
 msgstr "Identifica se l'autore dell'opera è un individuo o un ente."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:116
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:48
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:139
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:55
 msgid "Date"
 msgstr "Data"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:117
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:140
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 msgstr ""
-"Informazioni sulla data di nascita e di decesso di una persona. Utile per "
-"distinguere gli omonimi."
+"Informazioni sulla data di nascita e di decesso di una persona. Utile per"
+" distinguere gli omonimi."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:121
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:144
 msgid "Qualifier"
 msgstr "Qualificazione"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:122
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:145
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 msgstr ""
-"Informazioni che qualificano la persona, come la sua occupazione. Utile per "
-"distinguere gli omonimi."
+"Informazioni che qualificano la persona, come la sua occupazione. Utile "
+"per distinguere gli omonimi."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:129
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:152
 msgid "Publishers"
 msgstr " Editori"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:130
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:153
 msgid "Publisher(s) of the resource."
 msgstr "Editore della risorsa."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:139
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:162
 msgid "Publisher's name."
 msgstr "Nome dell'editore."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:148
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:171
 msgid "Place of publication"
 msgstr "Luogo di pubblicazione"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:149
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:172
 msgid "Publisher's place of publication."
 msgstr "Luogo di pubblicazione dell'editore."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:162
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:185
 msgid ""
-"Date of the publication. This must be an integer, ie 1989, 453, -50. Used to"
-" sort search results. Once this field is set, a free formed date of "
+"Date of the publication. This must be an integer, ie 1989, 453, -50. Used"
+" to sort search results. Once this field is set, a free formed date of "
 "publication can be added in the next field."
 msgstr ""
-"Data di pubblicazione. Deve essere una cifra, per esempio 1989, 453, -50, "
-"utilizzata per filtrare i risultati della ricerca. Una volta compilato il "
-"campo, è possibile aggiungere una data di pubblicazione in forma libera nel "
-"campo successivo."
+"Data di pubblicazione. Deve essere una cifra, per esempio 1989, 453, -50,"
+" utilizzata per filtrare i risultati della ricerca. Una volta compilato "
+"il campo, è possibile aggiungere una data di pubblicazione in forma "
+"libera nel campo successivo."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:166
-msgid ""
-"Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:189
+msgid "Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
 msgstr "Deve essere un numero, da -999999 a +2050. Nessun prefisso richiesto."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:169
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:192
 msgid "Date of publication (free formed)"
 msgstr "Data di pubblicazione (visualizzata)"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:170
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:193
 msgid ""
 "Date of the publication in a free form. If there's a normalized date of "
 "publication, then a free formed date can be added to be displayed."
 msgstr ""
-"Data di pubblicazione (visualizzata). Se esiste una data di pubblicazione in"
-" forma standard, è possibile aggiungere e visualizzare una data libera."
+"Data di pubblicazione (visualizzata). Se esiste una data di pubblicazione"
+" in forma standard, è possibile aggiungere e visualizzare una data "
+"libera."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:175
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:198
 msgid "Extent"
 msgstr "Importanza materiale"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:176
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:199
 msgid "Extent of the resource, ie number of pages or volumes."
-msgstr ""
-"Importanza materiale della risorsa, ad esempio numero di pagine o volumi."
+msgstr "Importanza materiale della risorsa, ad esempio numero di pagine o volumi."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:181
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:204
 msgid "Other Material Characteristics"
 msgstr "Altre caratteristiche dei materiali"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:182
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:205
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
 msgstr ""
-"Altre caratteristiche dei materiali, ad esempio illustrazioni, in bianco e "
-"nero o a colori."
+"Altre caratteristiche dei materiali, ad esempio illustrazioni, in bianco "
+"e nero o a colori."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:187
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:210
 msgid "Format"
 msgstr "Formato"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:188
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:211
 msgid "Format of the resource, ie dimensions in cm."
 msgstr "Formato della risorsa, ad esempio dimensioni in cm."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:197
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:220
 msgid "Additional materials"
 msgstr "Materiale di accompagnamento"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:198
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:221
 msgid "Accompanying material of the resource, ie maps."
 msgstr "Materiali che accompagnano la risorsa, ad esempio mappe."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:203
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:102
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:226
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:109
 msgid "Series"
 msgstr "Collezione"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:204
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:227
 msgid "Series to which belongs the resource."
 msgstr "Collezione cui appartiene la risorsa."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:216
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:239
 msgid "Title of the series."
 msgstr "Titolo della collezione."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:220
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:243
 msgid "Numbering"
 msgstr "Numerazione"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:221
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:244
 msgid "Numbering of the resource within the series."
 msgstr "Numerazione delle risorse all'interno della raccolta."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:228
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:251
 msgid "Note"
 msgstr "Nota"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:229
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:252
 msgid "Note on the resource."
 msgstr "Nota sulla risorsa."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:238
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:63
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:261
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:70
 msgid "Abstract"
 msgstr "Riassunto"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:239
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:262
 msgid "Abstract of the resource."
 msgstr "Riassunto della risorsa."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:249
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:272
 msgid "Persistent identifiers of the resource, ie reroID and ISBN."
 msgstr "Identificatori perenni della risorsa, ad esempio reroID e ISBN."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:255
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:278
 msgid "reroID"
 msgstr "reroID"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:256
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:279
 msgid "Corresponding reroID of the original RERO record."
-msgstr ""
-"reroID corrispondente risvolto del record bibliografico RERO originale."
+msgstr "reroID corrispondente risvolto del record bibliografico RERO originale."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:261
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:284
 msgid "bnfID"
 msgstr "bnfID"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:262
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:285
 msgid "Corresponding bnfID of the original BNF record."
 msgstr "bnfID corrispondente del record bibliografico BNF originale."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:268
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:291
 msgid "ISBN of the resource."
 msgstr "ISBN della risorsa."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:271
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:294
 msgid "Should be a valid ISBN-13 without dashes."
 msgstr "Deve essere un ISBN-13 valido senza trattini."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:276
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:299
 msgid "Subject"
 msgstr "Oggetto"
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:277
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:300
 msgid "Subject of the resource."
 msgstr "Oggetto della risorsa."
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:286
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:309
 msgid "Document availability"
 msgstr "Disponibilità del documento"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:13
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:21
 msgid "Author"
 msgstr "Autore o autori"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:34
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:41
 msgid "Publisher"
 msgstr " Editori"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:80
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:87
 msgid "Physical description"
 msgstr "Descrizione fisica"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:91
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:98
 msgid "Additional Materials"
 msgstr "Materiale di accompagnamento"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:120
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:127
 msgid "Uniform title"
 msgstr "Titolo uniforme"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:131
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:138
+msgid "Is part of"
+msgstr ""
+
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:149
 msgid "Subjects"
 msgstr "Oggetto"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:142
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:160
 msgid "Notes"
 msgstr "Nota"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:171
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:183
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:189
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:201
 msgid "Source"
 msgstr "Fonte"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:194
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:212
 msgid "Permalink"
 msgstr "Permalink"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:213
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:231
 msgid "Items"
 msgstr "Esemplare"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:217
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:235
 #: reroils_data/members_locations/templates/reroils_data/detailed_view_members_locations.html:61
 #: reroils_data/organisations_members/templates/reroils_data/detailed_view_organisations_members.html:38
 msgid "Add"
 msgstr "Aggiungere"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:230
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:248
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:28
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_head.html:15
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_personal.html:9
@@ -568,16 +587,16 @@ msgstr "Aggiungere"
 msgid "Barcode"
 msgstr "Codice a barre"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:245
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:263
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:53
 msgid "Call Number"
 msgstr "Classificazione"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:256
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:274
 msgid "Library"
 msgstr "Biblioteca"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:267
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:285
 #: reroils_data/items/form_options/items/item-v0.0.1.json:76
 #: reroils_data/items/templates/reroils_data/_item_head.html:33
 #: reroils_data/locations/form_options/locations/location-v0.0.1.json:26
@@ -585,24 +604,25 @@ msgstr "Biblioteca"
 msgid "Location"
 msgstr "Localizzazione"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:280
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:298
 msgid "Rank"
 msgstr "Posizione nella lista"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:292
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:310
 #: reroils_data/items/form_options/items/item-v0.0.1.json:109
+#: reroils_data/items/templates/reroils_data/_item_head.html:50
 msgid "Status"
 msgstr "Stato"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:307
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:325
 msgid "Request"
 msgstr "Richiedere"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:311
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:329
 msgid "Available Pickup Locations"
 msgstr "Localizzazioni di ritiro"
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:341
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:359
 msgid "Export Formats"
 msgstr "Formati di esportazione"
 
@@ -663,6 +683,7 @@ msgid "Barcode of the item."
 msgstr "Codice a barre dell'esemplare."
 
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:34
+#: reroils_data/items/templates/reroils_data/_item_head.html:9
 msgid "Call number"
 msgstr "Classificazione"
 
@@ -693,10 +714,6 @@ msgstr "Numero di rinnovi"
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:86
 msgid "Item renewal count."
 msgstr "Numero di rinnovi del esemplare."
-
-#: reroils_data/items/templates/reroils_data/_item_head.html:9
-msgid "Callnumber"
-msgstr "Segnatura"
 
 #: reroils_data/items/templates/reroils_data/_item_head.html:25
 msgid "Document"
@@ -992,7 +1009,8 @@ msgstr "Numero di telefono con l'indicazione internazionale, senza spazi."
 
 #: reroils_data/patrons/jsonschemas/patrons/patron-v0.0.1.json:80
 msgid ""
-"Phone number with the international prefix, without spaces, ie +41221234567."
+"Phone number with the international prefix, without spaces, ie "
+"+41221234567."
 msgstr ""
 "Numero di telefono con l'indicazione internazionale, senza spazi, cioè "
 "+41221234567."
@@ -1074,3 +1092,7 @@ msgstr "Nessuna prenotazione"
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:56
 msgid "Belongs to"
 msgstr "Appartiene a"
+
+#~ msgid "Callnumber"
+#~ msgstr "Segnatura"
+

--- a/reroils_data/translations/messages.pot
+++ b/reroils_data/translations/messages.pot
@@ -4,12 +4,11 @@
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
 #
-
 msgid ""
 msgstr ""
-"Project-Id-Version: reroils-data 0.1.0a13\n"
+"Project-Id-Version: reroils-data 0.1.0a16\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2018-06-26 10:22+0200\n"
+"POT-Creation-Date: 2018-08-10 07:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,19 +27,19 @@ msgid "available"
 msgstr ""
 
 #: reroils_data/filter.py:68
+msgid "on_site consultation"
+msgstr ""
+
+#: reroils_data/filter.py:70
 msgid "not available"
 msgstr ""
 
-#: reroils_data/filter.py:75
+#: reroils_data/filter.py:77
 msgid "due until"
 msgstr ""
 
-#: reroils_data/filter.py:77
+#: reroils_data/filter.py:79
 msgid "requested"
-msgstr ""
-
-#: reroils_data/filter.py:81
-msgid "on_site consultation"
 msgstr ""
 
 #: reroils_data/documents/views.py:63
@@ -99,12 +98,12 @@ msgid "Submit"
 msgstr ""
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:26
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:248
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:271
 msgid "Identifiers"
 msgstr ""
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:38
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:20
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:21
 msgid "Document ID"
 msgstr ""
 
@@ -113,8 +112,8 @@ msgid "Persistent identifier, automatically generated."
 msgstr ""
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:50
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:267
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:159
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:290
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:177
 msgid "ISBN"
 msgstr ""
 
@@ -123,8 +122,8 @@ msgid "Import"
 msgstr ""
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:77
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:25
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:215
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:42
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:238
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:52
 msgid "Title"
 msgstr ""
@@ -213,15 +212,15 @@ msgid "Spanish"
 msgstr ""
 
 #: reroils_data/documents/form_options/documents/document-v0.0.1.json:215
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:161
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:184
 msgid "Date of publication"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:3
-msgid "Schema for book"
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:3
+msgid "Schema for document"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:14
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:15
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:17
 #: reroils_data/locations/jsonschemas/locations/location-v0.0.1.json:15
 #: reroils_data/members/jsonschemas/members/member-v0.0.1.json:14
@@ -230,66 +229,90 @@ msgstr ""
 msgid "Schema"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:15
-msgid "Schema to validate book document against."
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:16
+msgid "Schema to validate document against."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:26
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:27
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:26
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:129
+#: reroils_data/items/form_options/items/item-v0.0.1.json:84
+#: reroils_data/items/templates/reroils_data/_item_head.html:17
+#: reroils_data/patrons/templates/reroils_data/detailed_view_patrons.html:24
+msgid "Type"
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:27
+msgid "Document type."
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:29
+msgid "Required. Type of the document. Should be selected in the list below."
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:43
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:44
 msgid "Required. Entire title without statement of responsibility."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:32
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:49
 msgid "Proper or uniformed title"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:33
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:50
 msgid ""
 "Uniform title, a related or an analytical title that is controlled by an "
 "authority file or list, used as an added access point."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:42
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:59
+msgid "Is part of"
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:60
+msgid "Title of the host document."
+msgstr ""
+
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:65
 msgid "Languages"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:43
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:66
 msgid "List of languages for the resource."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:54
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:77
 msgid "Language"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:55
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:57
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:78
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:80
 msgid "Required. Language of the resource, primary or not."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:77
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:100
 msgid "Translated from"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:78
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:101
 msgid "Language from which a resource is translated."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:84
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:107
 msgid ""
 "Should be in the ISO 639 format, with 3 characters, ie <code>eng</code> "
 "for English."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:88
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:111
 msgid "Authors"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:89
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:112
 msgid "Author(s) of the resource. Can be either persons or organisations."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:101
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:138
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:124
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:161
 #: reroils_data/locations/jsonschemas/locations/location-v0.0.1.json:30
 #: reroils_data/members/jsonschemas/members/member-v0.0.1.json:29
 #: reroils_data/organisations/jsonschemas/organisations/organisation-v0.0.1.json:24
@@ -298,243 +321,240 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:102
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:125
 msgid "Person's or organisation's name."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:106
-#: reroils_data/items/form_options/items/item-v0.0.1.json:84
-#: reroils_data/items/templates/reroils_data/_item_head.html:17
-#: reroils_data/patrons/templates/reroils_data/detailed_view_patrons.html:24
-msgid "Type"
-msgstr ""
-
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:107
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:130
 msgid "Identify if the author is a person or an organisation."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:116
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:48
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:139
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:55
 msgid "Date"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:117
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:140
 msgid ""
 "Information about the birth and the death of a person. Helpful to "
 "disambiguate people."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:121
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:144
 msgid "Qualifier"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:122
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:145
 msgid ""
 "Information about the person, ie her profession. Helpful to disambiguate "
 "people."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:129
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:152
 msgid "Publishers"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:130
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:153
 msgid "Publisher(s) of the resource."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:139
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:162
 msgid "Publisher's name."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:148
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:171
 msgid "Place of publication"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:149
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:172
 msgid "Publisher's place of publication."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:162
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:185
 msgid ""
 "Date of the publication. This must be an integer, ie 1989, 453, -50. Used"
 " to sort search results. Once this field is set, a free formed date of "
 "publication can be added in the next field."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:166
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:189
 msgid "Have to be an integer, from -9999 to +2050. Zero prefixes aren't needed."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:169
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:192
 msgid "Date of publication (free formed)"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:170
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:193
 msgid ""
 "Date of the publication in a free form. If there's a normalized date of "
 "publication, then a free formed date can be added to be displayed."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:175
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:198
 msgid "Extent"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:176
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:199
 msgid "Extent of the resource, ie number of pages or volumes."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:181
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:204
 msgid "Other Material Characteristics"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:182
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:205
 msgid ""
 "Other Material Characteristics, ie illustrations, black and with or "
 "coloured."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:187
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:210
 msgid "Format"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:188
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:211
 msgid "Format of the resource, ie dimensions in cm."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:197
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:220
 msgid "Additional materials"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:198
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:221
 msgid "Accompanying material of the resource, ie maps."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:203
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:102
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:226
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:109
 msgid "Series"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:204
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:227
 msgid "Series to which belongs the resource."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:216
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:239
 msgid "Title of the series."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:220
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:243
 msgid "Numbering"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:221
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:244
 msgid "Numbering of the resource within the series."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:228
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:251
 msgid "Note"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:229
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:252
 msgid "Note on the resource."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:238
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:63
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:261
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:70
 msgid "Abstract"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:239
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:262
 msgid "Abstract of the resource."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:249
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:272
 msgid "Persistent identifiers of the resource, ie reroID and ISBN."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:255
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:278
 msgid "reroID"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:256
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:279
 msgid "Corresponding reroID of the original RERO record."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:261
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:284
 msgid "bnfID"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:262
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:285
 msgid "Corresponding bnfID of the original BNF record."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:268
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:291
 msgid "ISBN of the resource."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:271
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:294
 msgid "Should be a valid ISBN-13 without dashes."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:276
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:299
 msgid "Subject"
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:277
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:300
 msgid "Subject of the resource."
 msgstr ""
 
-#: reroils_data/documents/jsonschemas/documents/book-v0.0.1.json:286
+#: reroils_data/documents/jsonschemas/documents/document-v0.0.1.json:309
 msgid "Document availability"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:13
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:21
 msgid "Author"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:34
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:41
 msgid "Publisher"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:80
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:87
 msgid "Physical description"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:91
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:98
 msgid "Additional Materials"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:120
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:127
 msgid "Uniform title"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:131
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:138
+msgid "Is part of"
+msgstr ""
+
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:149
 msgid "Subjects"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:142
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:160
 msgid "Notes"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:171
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:183
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:189
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:201
 msgid "Source"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:194
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:212
 msgid "Permalink"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:213
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:231
 msgid "Items"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:217
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:235
 #: reroils_data/members_locations/templates/reroils_data/detailed_view_members_locations.html:61
 #: reroils_data/organisations_members/templates/reroils_data/detailed_view_organisations_members.html:38
 msgid "Add"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:230
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:248
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:28
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_head.html:15
 #: reroils_data/patrons/templates/reroils_data/_patron_profile_personal.html:9
@@ -542,16 +562,16 @@ msgstr ""
 msgid "Barcode"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:245
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:263
 #: reroils_data/patrons/templates/reroils_data/patron_profile.html:53
 msgid "Call Number"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:256
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:274
 msgid "Library"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:267
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:285
 #: reroils_data/items/form_options/items/item-v0.0.1.json:76
 #: reroils_data/items/templates/reroils_data/_item_head.html:33
 #: reroils_data/locations/form_options/locations/location-v0.0.1.json:26
@@ -559,24 +579,25 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:280
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:298
 msgid "Rank"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:292
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:310
 #: reroils_data/items/form_options/items/item-v0.0.1.json:109
+#: reroils_data/items/templates/reroils_data/_item_head.html:50
 msgid "Status"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:307
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:325
 msgid "Request"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:311
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:329
 msgid "Available Pickup Locations"
 msgstr ""
 
-#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:341
+#: reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html:359
 msgid "Export Formats"
 msgstr ""
 
@@ -637,6 +658,7 @@ msgid "Barcode of the item."
 msgstr ""
 
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:34
+#: reroils_data/items/templates/reroils_data/_item_head.html:9
 msgid "Call number"
 msgstr ""
 
@@ -666,10 +688,6 @@ msgstr ""
 
 #: reroils_data/items/jsonschemas/items/item-v0.0.1.json:86
 msgid "Item renewal count."
-msgstr ""
-
-#: reroils_data/items/templates/reroils_data/_item_head.html:9
-msgid "Callnumber"
 msgstr ""
 
 #: reroils_data/items/templates/reroils_data/_item_head.html:25


### PR DESCRIPTION
How to test:
- Search article
- Check if the "is part of" field is present on brief and full view

Signed-off-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>