### PR TITLE
feat: document type in item detailed view

### DIFF
--- a/reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html
+++ b/reroils_data/documents_items/templates/reroils_data/detailed_view_documents_items.html
@@ -280,7 +280,6 @@
     </div>
     {% endif %}
 
-
     {% if item | number_of_requests > 0 %}
       {% if item | requested_this_item %}
         <div class="row">

--- a/reroils_data/items/api.py
+++ b/reroils_data/items/api.py
@@ -455,6 +455,7 @@ class Item(IlsRecord):
         data['member_name'] = member.get('name')
         data['requests_count'] = self.number_of_item_requests()
         data['available'] = self.available
+        is_part_of = self.get('is_part_of', None)
         for holding in data.get('_circulation', {}).get('holdings', []):
             pickup_member_pid = holding.get('pickup_member_pid')
             if pickup_member_pid:

--- a/reroils_data/items/templates/reroils_data/_item_head.html
+++ b/reroils_data/items/templates/reroils_data/_item_head.html
@@ -14,18 +14,36 @@
     </div>
     <div class="row">
         <div class="col-xs-3 col-sm-2">
-            {{_('Type')}}:
+            {{_('Item Type')}}:
         </div>
         <div class="col-xs-9 col-sm-10">
             {{item_dumps.item_type}}
         </div>
     </div>
+    {% if document.is_part_of %}
+    <div class="row">
+        <div class="col-xs-2">
+            {{_('Is part of')}}:
+        </div>
+        <div class="col-xs-9">
+            {{_(document.is_part_of)}}
+        </div>
+    </div>
+    {% endif %}
     <div class="row">
         <div class="col-xs-3 col-sm-2">
             {{_('Document')}}:
         </div>
         <div class="col-xs-9 col-sm-10">
             <a href="{{ '/documents/' + document.pid }}">{{ document.title }}</a>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-xs-2">
+            {{_('Document Type')}}:
+        </div>
+        <div class="col-xs-9">
+            {{_(document.type)}}
         </div>
     </div>
     <div class="row">


### PR DESCRIPTION
How to test:

- Login as Librarian
- Check if the "Document Type" field is present on full view of item
- search an article
- Check if the "Is part of" field is present on full view of item

Signed-off-by: Peter Weber <Peter.Weber@rero.ch>